### PR TITLE
It's OK with me if upgrade "fails"

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -56,7 +56,11 @@ m = Module.new do
   end
 
   def update_ruby
-    system('brew upgrade ruby-build') && system('brew bootstrap-rbenv-ruby')
+    success = true
+    if `brew outdated` =~ /^ruby-build$/
+      success = system('brew upgrade ruby-build')
+    end
+    success && system('brew bootstrap-rbenv-ruby')
   end
 end
 


### PR DESCRIPTION
For some arcane reason attempting to upgrade an up-to-date package with Homebrew is an "error". As a fix, check if it's outdated first before trying to upgrade it.

<!--
Hello! Thanks for your contribution - pull requests are welcome. Just to make
sure, though: Are you opening opening this PR on the public fork of this
repository? If not, head over there to create your PR:

https://github.com/umts/dev-training/compare

If so, then just a few more things:
-->

* [x] RSpec and Rubocop were run (`rake`)
* [x] Test coverage is good
* [ ] Documentation was updated if public methods changed (`rake rerdoc`)